### PR TITLE
Strip only leading and trailing whitespace

### DIFF
--- a/lib/saxy/element.rb
+++ b/lib/saxy/element.rb
@@ -1,6 +1,6 @@
 module Saxy
   class Element
-    attr_reader :attributes, :value
+    attr_reader :attributes
 
     def initialize
       @attributes = {}
@@ -14,10 +14,14 @@ module Saxy
     end
 
     def append_value(string)
-      unless (string = string.strip).empty?
+      if @value || !string.strip.empty?
         @value ||= ""
         @value << string
       end
+    end
+
+    def value
+      @value && @value.strip
     end
 
     def to_h

--- a/spec/saxy/element_spec.rb
+++ b/spec/saxy/element_spec.rb
@@ -8,10 +8,12 @@ describe Saxy::Element do
     expect(element.value).to be_nil
   end
 
-  it "should append stripped value" do
-    element.append_value(" foo ")
-    element.append_value(" bar ")
-    expect(element.value).to eq("foobar")
+  it "should strip leading and trailing whitespace" do
+    element.append_value(" one two ")
+    element.append_value("&")
+    element.append_value(" three\nfour")
+    element.append_value("\t\t")
+    expect(element.value).to eq("one two & three\nfour")
   end
 
   it "should dump as string when no attributes are set" do


### PR DESCRIPTION
Given the following XML

```
<root>
  <test>
    This &amp; That
  </test>
</root>
```

We would like the whitespace around the ampersand to be preserved such that we receive 'This & That' as the parsed XML.

Without this change we receive 'This&That'.

This commit/fix was added to a later version of Saxy by the original author. Unfortunately, we cannot upgrade to the latest tagged release due to other breaking changes.

See https://github.com/humante/saxy/commit/399e3a6c471a11b6bba4558d82bb545d8ac2e299#diff-f38949c025420652d7274af5e8b61ddc for more info.