### PR TITLE
Change ParsingError to inherit from StandardError not Exception

### DIFF
--- a/lib/saxy/parsing_error.rb
+++ b/lib/saxy/parsing_error.rb
@@ -1,4 +1,4 @@
 module Saxy
-  class ParsingError < ::Exception
+  class ParsingError < ::StandardError
   end
 end


### PR DESCRIPTION
# Purpose
The promote app's `PartnerFeedSequenceRunner` rescues `StandardError` errors and reports them to `Partner::Feed::Audit` objects. Currently `Saxy::ParsingError` is not rescued and reported and even though the feed stops running, and the audit object reports that the feed is still running. With this change the audit object will know about the error.

# Approach
This is a commit cherry-picked from a more recent version of the repository that changes the `Saxy::ParsingError` to inherit from `StandardError` instead of `Exception`.

This commit has also been tagged `v0.5.6` for use with our [promote app](https://github.com/AdWerx/promote)